### PR TITLE
Fix compile error with repeated enums

### DIFF
--- a/src/protobuf/private/basetypes.nim
+++ b/src/protobuf/private/basetypes.nim
@@ -11,7 +11,7 @@ when cpuEndian == littleEndian:
     result = result or (result shr 32)
     result = result - (result shr 1)
 
-  proc getVarIntLen*(num: int | int64 | int32 | uint64 | uint32 | bool): int =
+  proc getVarIntLen*(num: int | int64 | int32 | uint64 | uint32 | bool | enum): int =
     ## Get's the length a number would take when written with the protobuf
     ## VarInt encoding.
     result = 1


### PR DESCRIPTION
Something like this
```proto
syntax = "proto3";

message ClientMsg {
  enum Input {
    Left = 0;
    Right = 1;
    Up = 2;
    Down = 3;
  }

  repeated Input inputs = 2;
}
```
will no longer raise this compilation error:
```
protobuf-nim/examples/example4.nim(18, 11) template/generic instantiation of `parseProto` from here
protobuf-nim/src/protobuf.nim(833, 36) Error: type mismatch: got <ClientMsg_Input>
but expected one of: 
proc getVarIntLen(num: int | int64 | int32 | uint64 | uint32 | bool): int

expression: getVarIntLen(
  if not contains(o.fields, 0):
    raise
      var e351634: owned(ref ValueError)
      new(e351634)
      e351634.msg = "Field \"inputs\" isn\'t initialized"
      e351634.parent = nil
      e351634
  o.private_inputs[i349934])
```