### PR TITLE
Fixes crashing macros with nested empty  messages

### DIFF
--- a/tests/temptynested.nim
+++ b/tests/temptynested.nim
@@ -1,0 +1,20 @@
+# From bug #23
+import "../src/protobuf"
+import streams
+import strutils
+
+const protoSpec = """
+syntax = "proto3";
+
+message Example2 {}
+
+message Example {
+    message ExampleNested {}
+}
+"""
+parseProto(protoSpec)
+
+var
+  a = new Example_ExampleNested
+  b = new Example2
+  c = new Example

--- a/tests/temptynested.nim
+++ b/tests/temptynested.nim
@@ -11,6 +11,12 @@ message Example2 {}
 message Example {
     message ExampleNested {}
 }
+
+message Example3{
+  int32 aField = 1;
+  message Child{}
+}
+
 """
 parseProto(protoSpec)
 
@@ -18,3 +24,5 @@ var
   a = new Example_ExampleNested
   b = new Example2
   c = new Example
+  d = new Example3
+  e = new Example3_Child


### PR DESCRIPTION
Prior to this nested messages with empty bodies would error and give an unhelpful "Is not a valid range" message.